### PR TITLE
fix: default port 4444 and custom port by PORT env

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -8,7 +8,7 @@ const db = require('./db/dbConnect')
 const bodyParser = require('body-parser');
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-
+const port = process.env.PORT||4444;
 app.use("/",route);
 
-app.listen(4444);
+app.listen(port,()=>console.log("Listening To Port "+port));


### PR DESCRIPTION
I have changed the Hardcoded port 4444 in main.js by assigning port defined at PORT environment variable and by default used port 4444.
This will allow contributors to use custom port on their local device 